### PR TITLE
API: Extended with filter for events

### DIFF
--- a/classes/Service/class.xoctEventAPI.php
+++ b/classes/Service/class.xoctEventAPI.php
@@ -118,6 +118,14 @@ class xoctEventAPI {
 		return true;
 	}
 
+	/**
+	 * @param array $filter
+	 * @return array
+	 */
+	public function filter(array $filter){
+		return \xoctEvent::getFiltered($filter);
+	}
+
 
 
 }


### PR DESCRIPTION
We also need the filter on the API to access existing events. Currently we have to do that natively by using: 

`\xoctEvent::getFiltered($filter);`

This is an issue, since we can not properly mock this static call in our code. The API calls however are nicely mockable (e.g. by mockery).