### PR TITLE
fixed duplicated streams

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -23,7 +23,7 @@ class xoctEventGUI extends xoctGUI {
 	const CMD_REPORT_QUALITY = 'reportQuality';
 	const CMD_SCHEDULE = 'schedule';
 	const CMD_CREATE_SCHEDULED = 'createScheduled';
-    const CMD_DELIVER_VIDEO = 'deliverVideo';
+    	const CMD_DELIVER_VIDEO = 'deliverVideo';
 	const CMD_STREAM_VIDEO = 'streamVideo';
 	const ROLE_MASTER = "presenter";
 	const ROLE_SLAVE = "presentation";
@@ -565,6 +565,21 @@ class xoctEventGUI extends xoctGUI {
                 ];
             }
 		}, $medias);
+
+		if( xoctConf::getConfig(xoctConf::F_USE_STREAMING)) {
+
+			$filteredStreams = array();
+			foreach ( $streams as $stream)
+			{
+				$filteredStreams[$stream['content']] = $stream;
+			}
+
+			$streams = array();
+			foreach ($filteredStreams as $stream)
+			{
+				$streams[] = $stream;
+			}
+		}
 
 		$segmentFlavor = xoctPublicationUsage::find(xoctPublicationUsage::USAGE_SEGMENTS)->getFlavor();
 		$publication_usage_segments = xoctPublicationUsage::getUsage(xoctPublicationUsage::USAGE_SEGMENTS);


### PR DESCRIPTION
Aktuell ist es noch so, dass wenn Streaming Aktive ist, für jede Auflösung ein Stream anlegt wird. 
Das führt dazu das im neuen Paella Player unter der Stream Auswahl 3 Streams angezeigt werden, wobei der dritte Stream immer leer ist.

Der Patch reduziert die Streams wieder auf 2.

Sollte das ganze mal auf Presentation + Presenter 1 + Presenter 2 umgestellt werden sollte der Patch immer noch Funktionieren.