### PR TITLE
add configurable dynamic valid-until time to api sign call 

### DIFF
--- a/classes/Conf/class.xoctConf.php
+++ b/classes/Conf/class.xoctConf.php
@@ -39,6 +39,8 @@ class xoctConf extends ActiveRecord {
 	const F_NO_METADATA = 'no_metadata';
 	const F_INTERNAL_VIDEO_PLAYER = 'internal_player';
 	const F_SIGN_PLAYER_LINKS = 'sign_player_links';
+	const F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT = 'sign_player_links_overwrite_default';
+	const F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT = "sign_player_links_additional_time_percent";
 	const F_SIGN_DOWNLOAD_LINKS = 'sign_download_links';
 	const F_SIGN_THUMBNAIL_LINKS = 'sign_thumbnail_links';
 	const F_WORKFLOW_PARAMETERS = 'workflow_parameters';

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -467,6 +467,12 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS), xoctConf::F_SIGN_ANNOTATION_LINKS);
 		$this->addItem($cb);
+
+		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT), xoctConf::F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT);
+		$this->addItem($cb);
+
+		$cb = new ilNumberInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT), xoctConf::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT);
+		$this->addItem($cb);
 	}
 
 

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -518,11 +518,28 @@ class xoctEventGUI extends xoctGUI {
 
                 $dashURL = $streamingServerURL . "/smil:engage-player_" . $id . $smilURLIdentifier . ".smil/manifest_mpm4sav_mvlist.mpd";
 
-                if( xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS)) {
-                    $hlsURL = xoctSecureLink::sign($hlsURL);
+				if( xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS)) {
 
-                    $dashURL = xoctSecureLink::sign($dashURL);
-                }
+					if( xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT)) {
+						$durationInSeconds = $duration / 1000;
+
+						$additionalTimePercent = xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT) / 100;
+
+						$validUntil = gmdate("Y-m-d\TH:i:s\Z", time() +
+							$durationInSeconds +
+							$durationInSeconds *
+							$additionalTimePercent);
+
+						$hlsURL = xoctSecureLink::signWithEndTime($hlsURL, $validUntil);
+
+						$dashURL = xoctSecureLink::signWithEndTime($dashURL, $validUntil);
+					}
+					else{
+						$hlsURL = xoctSecureLink::sign($hlsURL);
+
+						$dashURL = xoctSecureLink::sign($dashURL);
+					}
+				}
 
                 return [
                     "type" => xoctMedia::MEDIA_TYPE_VIDEO,

--- a/classes/Request/class.xoctRequest.php
+++ b/classes/Request/class.xoctRequest.php
@@ -421,6 +421,15 @@ class xoctRequest {
 		return $this->post($data);
 	}
 
+	public function signWithValidUntil($url, $validUntil) {
+		$this->checkBranch(array( self::BRANCH_SECURITY ));
+		$this->addPart('sign');
+		$data = array( 'url' => $url ,
+					   'valid-until' => $validUntil);
+
+		return $this->post($data);
+	}
+
 
 	/**
 	 * @return $this

--- a/classes/class.xoctSecureLink.php
+++ b/classes/class.xoctSecureLink.php
@@ -40,6 +40,28 @@ class xoctSecureLink {
 
 		return $data->url;
 	}
+
+	public static function signWithEndTime($url, $validuntil) {
+		// this should not be necessary anymore, since you can activate/deactivate the url signing in the config
+		//		if (!xoctEvent::$LOAD_PUB_SEPARATE) {
+		//			return $url;
+		//		}
+		if (!$url) {
+			return '';
+		}
+		if (isset(self::$cache[$url])) {
+			return self::$cache[$url];
+		}
+
+		$data = json_decode(xoctRequest::root()->security()->signWithValidUntil($url, $validuntil));
+
+		if ($data->error) {
+			return '';
+		}
+		self::$cache[$url] = $data->url;
+
+		return $data->url;
+	}
 }
 
 ?>

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -48,6 +48,8 @@ config_security#:#Security
 config_security_info#:#Erhöht die Sicherheit mithilfe von OpenCasts "Stream Security". Nur aktivieren, wenn OpenCast dafür konfiguriert ist.
 config_sign_annotation_links#:#Annotationslink signieren
 config_sign_player_links#:#Playerlink signieren
+config_sign_player_links_overwrite_default#:#Benutze Aufzeichnungsdauer als Dauer für die Gültigkeit der Signatur
+config_sign_player_links_additional_time_percent#:#Wieviel zusätzliche Zeit soll der Gültigkeit der Signatur in Prozent, abhängig von der Dauer, hinzugefügt werden?
 config_sign_download_links#:#Downloadlink signieren
 config_sign_thumbnail_links#:#Thumbnaillink signieren
 config_request_comb_lv#:#Request Kombinations Level

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -48,6 +48,8 @@ config_security#:#Security
 config_security_info#:#Improves the security by using OpenCasts "Stream Security". Only activate, if OpenCast is configured to use it.
 config_sign_annotation_links#:#Sign Annotation Link
 config_sign_player_links#:#Sign Player Link
+config_sign_player_links_overwrite_default#:#Use event duration for the validity of the signature
+config_sign_player_links_additional_time_percent#:# How much additional time should be added to the validity of the signature in percent, depending on the event duration?
 config_sign_download_links#:#Sign Download Link
 config_sign_thumbnail_links#:#Sign Thumbnail Link
 config_request_comb_lv#:#Request Combination Level


### PR DESCRIPTION
to prevent timeouts on signed urls from e.g. wowza on longer videos, due to a configurable default of 7200s (2 hours) in opencasts external endpoint we added a dynamic valid-until based on the event duration with an optional percent value added on top to allow pauses.