### PR TITLE
Fix Misspelled Name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ILIAS-Plugin OpenCast
+# ILIAS-Plugin Opencast
 
 ### Installation
 Start at your ILIAS root directory

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -13,7 +13,7 @@ config_curl#:#cURL
 config_curl_debug_level#:#Debug-Level
 config_curl_password#:#API-Passwort
 config_curl_username#:#API-Benutzername
-config_editor_link#:#Link zum OpenCast-Video-Editor
+config_editor_link#:#Link zum Opencast-Video-Editor
 config_editor_link_info#:#Als Platzhalter kann &#123event_id} verwendet werden. Bsp: https://myopencast.com/external-url/events/&#123event_id}/editor
 config_eula#:#Nutzungsvereinbarung
 config_events#:#Aufzeichnungen
@@ -27,7 +27,7 @@ config_log_level_2#:#MEDIUM
 config_log_level_3#:#HIGH
 config_log_level_4#:#ULTRA
 config_msg_success#:#Gespeichert
-config_roles#:#OpenCast-Rollen
+config_roles#:#Opencast-Rollen
 config_role_anonymous#:#Anonym
 config_role_external_application_member#:#External Application Member
 config_role_ext_application#:#External Application
@@ -45,7 +45,7 @@ config_workflow#:#Processing-Workflow-ID
 config_workflow_unpublish#:#Unpublish-Workflow-ID
 config_advanced#:#Erweitert
 config_security#:#Security
-config_security_info#:#Erhöht die Sicherheit mithilfe von OpenCasts "Stream Security". Nur aktivieren, wenn OpenCast dafür konfiguriert ist.
+config_security_info#:#Erhöht die Sicherheit mithilfe von Opencasts "Stream Security". Nur aktivieren, wenn Opencast dafür konfiguriert ist.
 config_sign_annotation_links#:#Annotationslink signieren
 config_sign_player_links#:#Playerlink signieren
 config_sign_player_links_overwrite_default#:#Benutze Aufzeichnungsdauer als Dauer für die Gültigkeit der Signatur
@@ -54,32 +54,32 @@ config_sign_player_links_additional_time_percent_info#:#Wieviel zusätzliche Zei
 config_sign_download_links#:#Downloadlink signieren
 config_sign_thumbnail_links#:#Thumbnaillink signieren
 config_request_comb_lv#:#Request Kombinations Level
-config_request_comb_lv_info#:#Definiert die Zusammensetzung der Anfragen, mit welchen die Events von OpenCast geholt werden (viele kleine/wenige grosse Anfragen). Dies hat keinen Einfluss auf die Funktionalität, beeinflusst jedoch die Performanz.
+config_request_comb_lv_info#:#Definiert die Zusammensetzung der Anfragen, mit welchen die Events von Opencast geholt werden (viele kleine/wenige grosse Anfragen). Dies hat keinen Einfluss auf die Funktionalität, beeinflusst jedoch die Performanz.
 config_groups#:#Opencast-Gruppen
 config_group_producers#:#ILIAS Producers
 config_std_roles#:#Standardrollen
 config_std_roles_info#:#Die hier angegebenen Rollen erhalten Schreib- und Leserechte beim Erstellen eines Events oder einer Serie.
 config_api_base_info#:#z.B.: https://myopencast.com/api
 config_audio_allowed_info#:#Wenn aktiviert, können neben Video-Dateien auch Audio-Dateien hochgeladen werden.
-config_curl_username_info#:#Benutzeraccount in OpenCast, der zur Kommunikation über die API genutzt wird (benötigt genügend Rechte in OC)
+config_curl_username_info#:#Benutzeraccount in Opencast, der zur Kommunikation über die API genutzt wird (benötigt genügend Rechte in OC)
 config_curl_password_info#:#Passwort zum oben angegebenen Account.
 config_curl_debug_level_info#:#Detaillierungsgrad der Einträge im Log.
 config_streaming_url_info#:#Wowza URL für adaptive streaming. Bsp: https://wowza.myopencast.com:8090/opencast-engage
 config_use_streaming_info#:#Wenn aktive werden die MP4 Streams aus der API durch passende Streaming URLs ersetzt
 config_activate_cache_info#:#Verbessert die Ladezeiten der Videolisten durch lokales Speichern. Kann vorübergehend zu falschen (nicht aktuellen) Metadaten führen.
 config_use_modals_info#:#Wenn aktiviert: Beim Abspielen von Videos wird kein neues Browserfenster geöffnet, sondern der Player wird im aktuellen Fenster angezeigt.
-config_workflow_info#:#ID des workflows, welcher nach dem Hochladen eines Videos in OpenCast angewendet wird.
+config_workflow_info#:#ID des workflows, welcher nach dem Hochladen eines Videos in Opencast angewendet wird.
 config_workflow_unpublish_info#:#ID des workflows, welcher vor dem Löschen eines Videos in Opencast angewendet wird. Benötigt API-Version 1.1.0.
-config_user_mapping_info#:#Benutzerfeld in ILIAS, welches zur Identifikation eines Benutzers in OpenCast verwendet werden soll.
-config_group_producers_info#:#Benutzer mit dem Recht "Videos editieren" werden vom Plugin in der hier angegebenen OpenCast-Gruppe eingeschrieben, um dadurch Zugriff auf OpenCast zu erhalten.
-config_role_user_prefix_info#:#Benutzereigene Rolle in OpenCast. Wird auf Serien gesetzt, um dem Benutzer genügend Rechte in OpenCast einzuräumen. Bsp: ROLE_USER_&#123IDENTIFIER}
-config_role_ivt_external_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in OpenCast existieren. Bsp: ROLE_OWNER_&#123IDENTIFIER}
-config_role_ivt_email_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in OpenCast existieren. Bsp: ROLE_OWNER_EMAIL_&#123IDENTIFIER}
+config_user_mapping_info#:#Benutzerfeld in ILIAS, welches zur Identifikation eines Benutzers in Opencast verwendet werden soll.
+config_group_producers_info#:#Benutzer mit dem Recht "Videos editieren" werden vom Plugin in der hier angegebenen Opencast-Gruppe eingeschrieben, um dadurch Zugriff auf Opencast zu erhalten.
+config_role_user_prefix_info#:#Benutzereigene Rolle in Opencast. Wird auf Serien gesetzt, um dem Benutzer genügend Rechte in Opencast einzuräumen. Bsp: ROLE_USER_&#123IDENTIFIER}
+config_role_ivt_external_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in Opencast existieren. Bsp: ROLE_OWNER_&#123IDENTIFIER}
+config_role_ivt_email_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in Opencast existieren. Bsp: ROLE_OWNER_EMAIL_&#123IDENTIFIER}
 config_identifier_to_uppercase#:#User-Mapping in Grossbuchstaben
 config_no_metadata#:#Ohne Metadaten
 config_no_metadata_info#:#Ab API Version 1.1.0 müssen die Metadaten nicht mehr separat geholt werden, mit dieser Option kann somit die Performanz verbessert werden. In allen älteren Versionen wird diese Option allerdings zu einem Fehler führen.
 config_internal_player#:#Interner Video-Player
-config_internal_player_info#:#Wenn aktiviert, wird ein im Plugin integrierter Video-Player verwendet, statt an OpenCast weiterzuleiten.
+config_internal_player_info#:#Wenn aktiviert, wird ein im Plugin integrierter Video-Player verwendet, statt an Opencast weiterzuleiten.
 config_use_streaming#:#Benutze Streaming URLs
 config_streaming#:#Streaming
 config_streaming_url#:#Wowza URL
@@ -194,14 +194,14 @@ event_update#:#Speichern
 event_updateOwner#:#Besitzer speichern
 event_view#:#Anzeigen
 event_online#:#Aufzeichnung online
-event_online_info#:#Dies bezieht sich nur auf diese ILIAS-Installation und wird nicht auf OpenCast abgebildet
+event_online_info#:#Dies bezieht sich nur auf diese ILIAS-Installation und wird nicht auf Opencast abgebildet
 event_upload_select#:#Datei auswählen
 event_upload_clear#:#Zurücksetzen
 event_supported_filetypes#:#Unterstützte Dateitypen
 event_set_offline#:#Offline schalten
 event_created_unix#:#Datum
 event_set_online#:#Online schalten
-event_delete_confirm_w_duplicates#:#Das Löschen bewirkt, dass die Aufzeichnung definitiv gelöscht wird (auf OpenCast und in den anderen ILIAS-Verlinkungen). Wollen Sie diese Aufzeichnung wirklich löschen?
+event_delete_confirm_w_duplicates#:#Das Löschen bewirkt, dass die Aufzeichnung definitiv gelöscht wird (auf Opencast und in den anderen ILIAS-Verlinkungen). Wollen Sie diese Aufzeichnung wirklich löschen?
 event_state_failed_owner#:#Fehlgeschlagen. Melden Sie sich bei Ihrer Supportstelle.
 event_state_running_owner#:#Wird konvertiert, für andere Studierende noch nicht sichtbar
 event_report_date_modification#:#Terminanpassungen melden
@@ -225,8 +225,8 @@ owner_only_one_owner#:#Es kann nur ein Besitzer pro Video ausgewählt werden.
 invitations_back#:#Zurück
 invitations_header#:#Zugriffsrechte erteilen
 invitations_none_available#:#Keine verfügbar
-obj_xoct#:#OpenCast
-objs_xoct#:#OpenCast
+obj_xoct#:#Opencast
+objs_xoct#:#Opencast
 perm_upload#:#Upload
 perm_edit_videos#:#Videos Editieren
 publication_usage_add#:#Hinzufügen
@@ -347,21 +347,21 @@ subtab_workflow_params#:#Workflow-Parameter
 upload_token_channel_id#:#Series-ID
 upload_token_daily_upload_token#:#Token
 upload_token_upload_token#:#Upload-Token
-xoct_new#:#OpenCast-Series erstellen
+xoct_new#:#Opencast-Series erstellen
 xoct_rep_robj_xoct_perm_upload#:#Benutzer kann Videos hochladen
 xoct_rep_robj_xoct_perm_edit_videos#:#Benutzer kann Videos editieren
-xoct_visible#:#OpenCast-Objekt ist sichtbar
-xoct_read#:#Lesezugriff auf OpenCast-Objekt
-xoct_write#:#Einstellungen eines OpenCast-Objekts bearbeiten
-xoct_delete#:#OpenCast-Objekt löschen oder verschieben
-xoct_edit_permission#:#Rechteeinstellungen des OpenCast-Objektes ändern
+xoct_visible#:#Opencast-Objekt ist sichtbar
+xoct_read#:#Lesezugriff auf Opencast-Objekt
+xoct_write#:#Einstellungen eines Opencast-Objekts bearbeiten
+xoct_delete#:#Opencast-Objekt löschen oder verschieben
+xoct_edit_permission#:#Rechteeinstellungen des Opencast-Objektes ändern
 form_msg_select#:#Bitte wählen Sie zuerst eine Videodatei aus
 form_msg_not_supported#:#Dateityp wird nicht unterstützt
 info_linked_items#:#Verlinkungen
 info_linked_item#:#Verlinkung
 info_auto_publish_forced#:#Das Video wird automatisch publiziert, da Sie nicht über genügend Rechte verfügen, um es später manuell zu publizieren.
 msg_info_multiple_aftersave#:#Diese Serie hat mehrere Verlinkungen in ILIAS (siehe unter «Info»). Hochgeladene Aufzeichnungen werden in alle Verlinkungen hochgeladen.
-msg_creation_failed#:#Objekte vom Typ "OpenCast" können nur innerhalb von Kursen oder Gruppen angelegt werden.
+msg_creation_failed#:#Objekte vom Typ "Opencast" können nur innerhalb von Kursen oder Gruppen angelegt werden.
 msg_permission_templates_info#:#Die erstellten Vorlagen können beim Erstellen und Bearbeiten einer Serie ausgewählt werden, um die konfigurierte Rolle mit den entsprechenden Rechten und ACL-Actions auf der Serie zu setzen. Die Rollen der restlichen Vorlagen werden dabei entfernt.
 msg_confirm_delete_perm_template#:#Sind Sie sicher, dass Sie folgende Vorlage löschen möchten?
 msg_confirm_delete_reports#:#Sind Sie sicher, dass Sie folgende Meldungen löschen möchten?

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -13,7 +13,7 @@ config_curl#:#cURL
 config_curl_debug_level#:#Debug-Level
 config_curl_password#:#API-Password
 config_curl_username#:#API-Username
-config_editor_link#:#Link to OpenCast Video Editor
+config_editor_link#:#Link to Opencast Video Editor
 config_editor_link_info#:#The placeholder &#123event_id} can be used. E.g.: https://myopencast.com/external-url/events/&#123event_id}/editor
 config_eula#:#EULA
 config_events#:#Events
@@ -27,7 +27,7 @@ config_log_level_2#:#MEDIUM
 config_log_level_3#:#HIGH
 config_log_level_4#:#ULTRA
 config_msg_success#:#Saved
-config_roles#:#OpenCast Roles
+config_roles#:#Opencast Roles
 config_role_anonymous#:#Anonymous
 config_role_external_application_member#:#External Application Member
 config_role_ext_application#:#External Application
@@ -45,7 +45,7 @@ config_workflow#:#Processing Workflow ID
 config_workflow_unpublish#:#Unpublish Workflow ID
 config_advanced#:#Advanced
 config_security#:#Security
-config_security_info#:#Improves the security by using OpenCasts "Stream Security". Only activate, if OpenCast is configured to use it.
+config_security_info#:#Improves the security by using Opencasts "Stream Security". Only activate, if Opencast is configured to use it.
 config_sign_annotation_links#:#Sign Annotation Link
 config_sign_player_links#:#Sign Player Link
 config_sign_player_links_overwrite_default#:#Use event duration for the validity of the signature
@@ -54,14 +54,14 @@ config_sign_player_links_additional_time_percent_info#:#How much additional time
 config_sign_download_links#:#Sign Download Link
 config_sign_thumbnail_links#:#Sign Thumbnail Link
 config_request_comb_lv#:#Request Combination Level
-config_request_comb_lv_info#:#Defines the way the plugin is sending requests to fetch events from OpenCast (many small/few large requests). This has no impact on the functionality, yet it affects the performance.
+config_request_comb_lv_info#:#Defines the way the plugin is sending requests to fetch events from Opencast (many small/few large requests). This has no impact on the functionality, yet it affects the performance.
 config_groups#:#Opencast Groups
 config_group_producers#:#ILIAS Producers
 config_std_roles#:#Standard roles
 config_std_roles_info#:#These roles are given read and write permissions when creating a series or an event.
 config_api_base_info#:#e.g.: https://myopencast.com/api
 config_audio_allowed_info#:#Allows the upload of audio files.
-config_curl_username_info#:#User account in OpenCast which will be used to communicate over the API (needs enough permissions in OC).
+config_curl_username_info#:#User account in Opencast which will be used to communicate over the API (needs enough permissions in OC).
 config_curl_password_info#:#Password for above account.
 config_curl_debug_level_info#:#Level of detail for log entries.
 config_use_streaming#:#Use Streaming URLs
@@ -69,18 +69,18 @@ config_streaming_url_info#:#Wowza URL for adaptive streaming. E.g.: https://wowz
 config_use_streaming_info#:#If active all mp4 files will be replaced by streaming urls
 config_activate_cache_info#:#Improves the loading time for event lists by storing events locally. Can lead to temporarily corrupt metadata.
 config_use_modals_info#:#When active: the video player will not be opened in a seperate window but in a overlaying "Modal" window.
-config_workflow_info#:#ID of the workflow which will be executed in OpenCast after uploading an event.
-config_workflow_unpublish_info#:#ID of the workflow which will be executed in OpenCast before deleting an event. Requires API version 1.1.0.
-config_user_mapping_info#:#Userfield in ILIAS which shall be used to identify the user in OpenCast.
-config_group_producers_info#:#Users with the permission "Edit Videos" will be assigned to this OpenCast group to obtain access to OpenCast.
-config_role_user_prefix_info#:#User specific role in OpenCast. Is used to grant the user permission on a series in OpenCast. Example: ROLE_USER_&#123IDENTIFIER}
-config_role_ivt_external_prefix_info#:#Indicates the owner of an event. This rules doesn't have to exist in OpenCast. Example: ROLE_OWNER_&#123IDENTIFIER}
+config_workflow_info#:#ID of the workflow which will be executed in Opencast after uploading an event.
+config_workflow_unpublish_info#:#ID of the workflow which will be executed in Opencast before deleting an event. Requires API version 1.1.0.
+config_user_mapping_info#:#Userfield in ILIAS which shall be used to identify the user in Opencast.
+config_group_producers_info#:#Users with the permission "Edit Videos" will be assigned to this Opencast group to obtain access to Opencast.
+config_role_user_prefix_info#:#User specific role in Opencast. Is used to grant the user permission on a series in Opencast. Example: ROLE_USER_&#123IDENTIFIER}
+config_role_ivt_external_prefix_info#:#Indicates the owner of an event. This rules doesn't have to exist in Opencast. Example: ROLE_OWNER_&#123IDENTIFIER}
 config_role_ivt_email_prefix_info#:#ROLE_OWNER_EMAIL_&#123IDENTIFIER}
 config_identifier_to_uppercase#:#User mapping in uppercase
 config_no_metadata#:#Without Metadata
 config_no_metadata_info#:#The metadata don't need to be fetched seperately in the latest API versions, therefore this option will improve the performance. However, this will lead to an error in previous versions.
 config_internal_player#:#Internal Video-Player
-config_internal_player_info#:#When active, the plugin will use an own video player instead of redirecting to OpenCast.
+config_internal_player_info#:#When active, the plugin will use an own video player instead of redirecting to Opencast.
 config_streaming#:#Streaming
 config_streaming_url#:#Wowza URL
 config_general#:#General
@@ -138,7 +138,7 @@ event_cut#:#Cut Event
 event_date#:#Date
 event_delete#:#Delete Event
 event_unpublish#:#Delete Publications
-event_delete_confirm#:#This will delete the Event in ILIAS and in OpenCast. Do you want to proceed?
+event_delete_confirm#:#This will delete the Event in ILIAS and in Opencast. Do you want to proceed?
 event_unpublish_confirm#:#You have to remove all publications from this event in order to delete this event. Do you want to proceed?
 event_description#:#Subtitle
 event_download#:#Download
@@ -194,7 +194,7 @@ event_update#:#Save
 event_updateOwner#:#Update owner
 event_view#:#View
 event_online#:#Event online
-event_online_info#:#An Event can be set offline on this ILIAS-Installation. The Event on OpenCast ist not affected
+event_online_info#:#An Event can be set offline on this ILIAS-Installation. The Event on Opencast ist not affected
 event_upload_select#:#Select file
 event_upload_clear#:#Reset
 event_supported_filetypes#:#Supported Filetypes
@@ -203,7 +203,7 @@ event_created_unix#:#Date
 event_event_created_unix#:#Date
 event_event_event_created_unix#:#Date
 event_set_online#:#Set online
-event_delete_confirm_w_duplicates#:#This will delete the Event in OpenCast and in every linked series in ILIAS. Do you want to proceed?
+event_delete_confirm_w_duplicates#:#This will delete the Event in Opencast and in every linked series in ILIAS. Do you want to proceed?
 event_state_failed_owner#:#Publication failed. Please contact the support.
 event_state_running_owner#:#Converting, not yet visible to other students
 event_report_date_modification#:#Report Date Modifications
@@ -227,8 +227,8 @@ owner_only_one_owner#:#Only one owner can be chosen per video.
 invitations_back#:#Back
 invitations_header#:#Grant Access to Event
 invitations_none_available#:#None available
-obj_xoct#:#OpenCast
-objs_xoct#:#OpenCast
+obj_xoct#:#Opencast
+objs_xoct#:#Opencast
 perm_upload#:#Upload
 perm_edit_videos#:#Edit Videos
 publication_usage_add#:#Add
@@ -352,10 +352,10 @@ upload_token_upload_token#:#Upload-Token
 xoct_new#:#Create openCast-Series
 xoct_rep_robj_xoct_perm_upload#:#User can upload videos
 xoct_rep_robj_xoct_perm_edit_videos#:#User can edit videos
-xoct_visible#:#OpenCast object is visible
-xoct_read#:#User has read access to OpenCast and can watch videos
-xoct_write#:#User can edit setting of OpenCast object
-xoct_delete#:#User can move or delete OpenCast object
+xoct_visible#:#Opencast object is visible
+xoct_read#:#User has read access to Opencast and can watch videos
+xoct_write#:#User can edit setting of Opencast object
+xoct_delete#:#User can move or delete Opencast object
 xoct_edit_permission#:#User can change permission settings
 form_msg_select#:#Please select fist a Videofile
 form_msg_not_supported#:#Filetype is not supported
@@ -363,7 +363,7 @@ info_linked_items#:#Links
 info_linked_item#:#Link
 info_auto_publish_forced#:#The video will be published automatically, since you don't own the rights to publish it manually.
 msg_info_multiple_aftersave#:#This Series has several links in ILIAS. Uploads will appear in every linked series, too.
-msg_creation_failed#:#Objects of type "OpenCast" can only be created in courses or groups.
+msg_creation_failed#:#Objects of type "Opencast" can only be created in courses or groups.
 msg_permission_templates_info#:#The created templates can be chosen from when creating or editing a series. If chosen, the configured role with the given permissions and actions will be set on the series. The roles of the residual templates will be removed.
 msg_confirm_delete_perm_template#:#Do you really want to delete the following template?
 msg_confirm_delete_reports#:#Do you really want to delete the following reports?
@@ -373,7 +373,7 @@ msg_confirm_delete_param#:#Do you really want to delete the following parameter?
 msg_load_workflow_params#:#The following parameters were returned by the workflow API. Would you like to load these (new parameters will be created, old ones will be deleted and already existing parameters will be updated)?
 msg_no_params_found#:#No parameters were found. The defined workflow may have no configuration panel, from which the parameters can be read. Please create the parameters manually.
 msg_success#:#Changes saved successfully.
-msg_confirm_overwrite_series_params#:#Warning: This will overwrite all locally adjusted configurations of workflow parameters in ILIAS OpenCast objects. Continue?
+msg_confirm_overwrite_series_params#:#Warning: This will overwrite all locally adjusted configurations of workflow parameters in ILIAS Opencast objects. Continue?
 msg_workflow_params_parsing_failed#:#Parsing of parameters via API failed:
 msg_workflow_parameters_info#:#Workflow Parameter are information which are passed to Opencast through the variable 'processing' when creating or scheduling an event. Note that the parameters must match the given workflow definition (Settings -> Events -> Processing Workflow ID). Clicking the button "Load Parameters via API" will try to load the parameters automatically - however this will only work if the workflow definition in Opencast has configured a configuration panel.
 table_column_default#:#Default


### PR DESCRIPTION
This patch fixes a number of occasions in the documentation and the
translations where Opencast was misspelled as `OpenCast`. If you look at
[the website](https://opencast.org) you will notice that there is no
capital `C` in Opencast's name.

The error also resides in this repositories name.
It would be nice if that could be fixed as well.