### PR TITLE
Add 1 second sleep after series POST request

### DIFF
--- a/classes/Series/class.xoctSeries.php
+++ b/classes/Series/class.xoctSeries.php
@@ -225,7 +225,8 @@ class xoctSeries extends APIObject {
 		$array['theme'] = $this->getTheme();
 
 		$data = json_decode(xoctRequest::root()->series()->post($array));
-
+		sleep(1);
+		
 		if ($data->identifier) {
 			$this->setIdentifier($data->identifier);
 		} else {


### PR DESCRIPTION
We found at the UzK with Opencast 8 when you create a new series from Ilias, the plugin alerts an error that the new series is not found. When in reality the series was correctly created.

The problem is a race condition, where Opencast still has not ready yet the series and doesn't appears, giving to the plugin error 404 when tries to get it.

The solution applied is to add one-second sleep, The performance difference is no noted by the user and adds reliability to the transaction.