### PR TITLE
Add Opencast Studio button

### DIFF
--- a/classes/Conf/class.xoctConf.php
+++ b/classes/Conf/class.xoctConf.php
@@ -49,6 +49,7 @@ class xoctConf extends ActiveRecord {
 	const F_WORKFLOW_PARAMETERS = 'workflow_parameters';
 	const F_AUDIO_ALLOWED = 'audio_allowed';
 	const F_CREATE_SCHEDULED_ALLOWED = 'create_scheduled_allowed';
+	const F_STUDIO_ALLOWED = 'oc_studio_allowed';
 	const F_VIDEO_PORTAL_LINK = 'video_portal_link';
 	const F_VIDEO_PORTAL_TITLE = 'video_portal_title';
 	const F_ENABLE_LIVE_STREAMS = 'enable_live_streams';

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -216,6 +216,10 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$cb->setInfo($this->parent_gui->txt(xoctConf::F_CREATE_SCHEDULED_ALLOWED . '_info'));
 		$this->addItem($cb);
 
+		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_STUDIO_ALLOWED), xoctConf::F_STUDIO_ALLOWED);
+		$cb->setInfo($this->parent_gui->txt(xoctConf::F_STUDIO_ALLOWED . '_info'));
+		$this->addItem($cb);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_AUDIO_ALLOWED), xoctConf::F_AUDIO_ALLOWED);
 		$cb->setInfo($this->parent_gui->txt(xoctConf::F_AUDIO_ALLOWED . '_info'));
 		$this->addItem($cb);

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -36,6 +36,7 @@ class xoctEventGUI extends xoctGUI {
 	const CMD_SWITCH_TO_TILES = 'switchToTiles';
 	const CMD_SHOW_CHAT_HISTORY = 'showChatHistory';
 	const CMD_CHANGE_TILE_LIMIT = 'changeTileLimit';
+	const CMD_OPENCAST_STUDIO = 'opencaststudio';
 
 	/**
 	 * @var xoctOpenCast
@@ -112,6 +113,15 @@ class xoctEventGUI extends xoctGUI {
 			$b = ilLinkButton::getInstance();
 			$b->setCaption('rep_robj_xoct_event_schedule_new');
 			$b->setUrl(self::dic()->ctrl()->getLinkTarget($this, self::CMD_SCHEDULE));
+			$b->setPrimary(true);
+			self::dic()->toolbar()->addButtonInstance($b);
+		}
+
+		// add "Opencast Studio" button
+		if (ilObjOpenCastAccess::checkAction(ilObjOpenCastAccess::ACTION_ADD_EVENT) && xoctConf::getConfig(xoctConf::F_STUDIO_ALLOWED)) {
+			$b = ilLinkButton::getInstance();
+			$b->setCaption('rep_robj_xoct_event_opencast_studio');
+			$b->setUrl(self::dic()->ctrl()->getLinkTarget($this, self::CMD_OPENCAST_STUDIO));
 			$b->setPrimary(true);
 			self::dic()->toolbar()->addButtonInstance($b);
 		}
@@ -451,6 +461,18 @@ class xoctEventGUI extends xoctGUI {
 		self::dic()->mainTemplate()->setContent($xoctEventFormGUI->getHTML());
 	}
 
+
+	/**
+	 * 
+	 */
+	public function opencaststudio(){
+		$xoctSeries =  $this->xoctOpenCast->getSeriesIdentifier();
+		$base = rtrim(xoctConf::getConfig(xoctConf::F_API_BASE), "/");
+		$base = str_replace('/api', '', $base);
+		$studio_link = $base . '/studio' . '?upload.seriesId=' . $xoctSeries;
+		header('Location:' . $studio_link);
+	}
+		
 
 	/**
 	 *

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -11,6 +11,8 @@ config_audio_allowed#:#Audio-Dateien
 config_cancel#:#Abbrechen
 config_create_scheduled_allowed#:#"Aufzeichnungstermin(e) planen" erlauben
 config_create_scheduled_allowed_info#:#Achtung: Das planen von Aufzeichnungsterminen ist erst ab Opencast API-Version 1.1.0 möglich.
+config_oc_studio_allowed#:#Opencast Studio aktivieren
+config_oc_studio_allowed_info#:#Ermöglichen Sie Benutzern den Zugriff auf Opencast Studio von Ilias aus (Erfordert Opencast > 8.3)
 config_curl#:#cURL
 config_curl_debug_level#:#Debug-Level
 config_curl_password#:#API-Passwort
@@ -179,6 +181,7 @@ event_multiple_start_time#:#Startzeit
 event_multiple_end#:#Enddatum
 event_multiple_end_time#:#Endzeit
 event_multiple_weekdays#:#Wiederholungen
+event_opencast_studio#:#Opencast Studio
 event_owner#:#Besitzer
 event_owner_select#:#--nicht zugewiesen--
 event_owner_username#:#Besitzer

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11,6 +11,8 @@ config_audio_allowed#:#Audio Files
 config_cancel#:#Cancel
 config_create_scheduled_allowed#:#Activate "Schedule Event(s)"
 config_create_scheduled_allowed_info#:#Warning: Scheduling events requires Opencast API v1.1.0.
+config_oc_studio_allowed#:#Enable Opencast Studio
+config_oc_studio_allowed_info#:#Allow users to access to Opencast Studio from Ilias (Requires Opencast > 8.3)
 config_curl#:#cURL
 config_curl_debug_level#:#Debug-Level
 config_curl_password#:#API-Password
@@ -179,6 +181,7 @@ event_multiple_start_time#:#Start Time
 event_multiple_end#:#End Date
 event_multiple_end_time#:#End Time
 event_multiple_weekdays#:#Repeat on
+event_opencast_studio#:#Opencast Studio
 event_owner#:#Owner
 event_owner_select#:#--not assigned--
 event_owner_username#:#Owner


### PR DESCRIPTION
Because of the Coronavirus pandemic, the Opencast team has added a feature to the new minor release (8.2) called "Opencast Studio", that allows users to record directly from their web browsers.

This PR adds a button in the Ilias plugin to access this feature directly. 
![Screenshot 2020-03-25 at 18 22 14](https://user-images.githubusercontent.com/8040628/77566995-c7a0b700-6ec6-11ea-9ffb-ddee97cdb70b.png)

It can be enabled by the administrator in the config panel.
![Screenshot 2020-03-25 at 18 23 15](https://user-images.githubusercontent.com/8040628/77567004-ca9ba780-6ec6-11ea-9a17-8bb0d32a2941.png)

Note: Because of a bug in opencast, this feature will work correctly after the patch [1487](https://github.com/opencast/opencast/pull/1487), it will be included in Opencast 8.3.
