### PR TITLE
Implement duration/ip support for all signing requests

### DIFF
--- a/classes/Conf/class.xoctConf.php
+++ b/classes/Conf/class.xoctConf.php
@@ -34,6 +34,7 @@ class xoctConf extends ActiveRecord {
 	const F_UPLOAD_TOKEN = 'upload_token';
 	const F_SIGN_ANNOTATION_LINKS = 'sign_annotation_links';
 	const F_SIGN_ANNOTATION_LINKS_TIME = 'sign_annotation_links_time';
+	const F_SIGN_ANNOTATION_LINKS_WITH_IP = 'sign_annotation_links_with_ip';
 	const F_REQUEST_COMBINATION_LEVEL = 'request_comb_lv';
 	const F_EDITOR_LINK = 'editor_link';
 	const SEP_EVERYTHING = 1;
@@ -44,10 +45,13 @@ class xoctConf extends ActiveRecord {
 	const F_SIGN_PLAYER_LINKS = 'sign_player_links';
 	const F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT = 'sign_player_links_overwrite_default';
 	const F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT = "sign_player_links_additional_time_percent";
+	const F_SIGN_PLAYER_LINKS_WITH_IP = "sign_player_links_with_ip";
 	const F_SIGN_DOWNLOAD_LINKS = 'sign_download_links';
 	const F_SIGN_DOWNLOAD_LINKS_TIME = 'sign_download_links_time';
+	const F_SIGN_DOWNLOAD_LINKS_WITH_IP = 'sign_download_links_with_ip';
 	const F_SIGN_THUMBNAIL_LINKS = 'sign_thumbnail_links';
 	const F_SIGN_THUMBNAIL_LINKS_TIME = 'sign_thumbnail_links_time';
+	const F_SIGN_THUMBNAIL_LINKS_WITH_IP = 'sign_thumbnail_links_with_ip';
 	const F_WORKFLOW_PARAMETERS = 'workflow_parameters';
 	const F_AUDIO_ALLOWED = 'audio_allowed';
 	const F_CREATE_SCHEDULED_ALLOWED = 'create_scheduled_allowed';

--- a/classes/Conf/class.xoctConf.php
+++ b/classes/Conf/class.xoctConf.php
@@ -33,6 +33,7 @@ class xoctConf extends ActiveRecord {
 	const F_LICENSES = 'licenses';
 	const F_UPLOAD_TOKEN = 'upload_token';
 	const F_SIGN_ANNOTATION_LINKS = 'sign_annotation_links';
+	const F_SIGN_ANNOTATION_LINKS_TIME = 'sign_annotation_links_time';
 	const F_REQUEST_COMBINATION_LEVEL = 'request_comb_lv';
 	const F_EDITOR_LINK = 'editor_link';
 	const SEP_EVERYTHING = 1;
@@ -44,7 +45,9 @@ class xoctConf extends ActiveRecord {
 	const F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT = 'sign_player_links_overwrite_default';
 	const F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT = "sign_player_links_additional_time_percent";
 	const F_SIGN_DOWNLOAD_LINKS = 'sign_download_links';
+	const F_SIGN_DOWNLOAD_LINKS_TIME = 'sign_download_links_time';
 	const F_SIGN_THUMBNAIL_LINKS = 'sign_thumbnail_links';
+	const F_SIGN_THUMBNAIL_LINKS_TIME = 'sign_thumbnail_links_time';
 	const F_WORKFLOW_PARAMETERS = 'workflow_parameters';
 	const F_AUDIO_ALLOWED = 'audio_allowed';
 	const F_CREATE_SCHEDULED_ALLOWED = 'create_scheduled_allowed';

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -479,11 +479,17 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$cb_sub_2->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT . '_info'));
 		$cb_sub->addSubItem($cb_sub_2);
 
+		$cb_sub = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_PLAYER_LINKS_WITH_IP), xoctConf::F_SIGN_PLAYER_LINKS_WITH_IP);
+		$cb->addSubItem($cb_sub);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS), xoctConf::F_SIGN_DOWNLOAD_LINKS);
 		$this->addItem($cb);
 
 		$cb_sub = new ilNumberInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME), xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME);
 		$cb_sub->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME . '_info'));
+		$cb->addSubItem($cb_sub);
+
+		$cb_sub = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS_WITH_IP), xoctConf::F_SIGN_DOWNLOAD_LINKS_WITH_IP);
 		$cb->addSubItem($cb_sub);
 
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_THUMBNAIL_LINKS), xoctConf::F_SIGN_THUMBNAIL_LINKS);
@@ -493,11 +499,17 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$cb_sub->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME . '_info'));
 		$cb->addSubItem($cb_sub);
 
+		$cb_sub = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_THUMBNAIL_LINKS_WITH_IP), xoctConf::F_SIGN_THUMBNAIL_LINKS_WITH_IP);
+		$cb->addSubItem($cb_sub);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS), xoctConf::F_SIGN_ANNOTATION_LINKS);
 		$this->addItem($cb);
 
 		$cb_sub = new ilNumberInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME), xoctConf::F_SIGN_ANNOTATION_LINKS_TIME);
 		$cb_sub->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME . '_info'));
+		$cb->addSubItem($cb_sub);
+
+		$cb_sub = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS_WITH_IP), xoctConf::F_SIGN_ANNOTATION_LINKS_WITH_IP);
 		$cb->addSubItem($cb_sub);
 	}
 

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -482,11 +482,23 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS), xoctConf::F_SIGN_DOWNLOAD_LINKS);
 		$this->addItem($cb);
 
+		$cb_sub = new ilNumberInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME), xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME);
+		$cb_sub->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME . '_info'));
+		$cb->addSubItem($cb_sub);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_THUMBNAIL_LINKS), xoctConf::F_SIGN_THUMBNAIL_LINKS);
 		$this->addItem($cb);
 
+		$cb_sub = new ilNumberInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME), xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME);
+		$cb_sub->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME . '_info'));
+		$cb->addSubItem($cb_sub);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS), xoctConf::F_SIGN_ANNOTATION_LINKS);
 		$this->addItem($cb);
+
+		$cb_sub = new ilNumberInputGUI($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME), xoctConf::F_SIGN_ANNOTATION_LINKS_TIME);
+		$cb_sub->setInfo($this->parent_gui->txt(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME . '_info'));
+		$cb->addSubItem($cb_sub);
 	}
 
 

--- a/classes/Event/class.xoctEvent.php
+++ b/classes/Event/class.xoctEvent.php
@@ -607,7 +607,7 @@ class xoctEvent extends APIObject {
 		while (!$this->thumbnail_url && $i < count($possible_publications)) {
 			$url = $this->getFirstPublicationMetadataForUsage(xoctPublicationUsage::find($possible_publications[$i]))->getUrl();
 			if (xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS)) {
-				$this->thumbnail_url = xoctSecureLink::sign($url);
+				$this->thumbnail_url = xoctSecureLink::signThumbnail($url);
 			} else {
 				$this->thumbnail_url = $url;
 			}
@@ -629,9 +629,8 @@ class xoctEvent extends APIObject {
 		if (!isset($this->annotation_url)) {
 			$url = $this->getFirstPublicationMetadataForUsage(xoctPublicationUsage::find(xoctPublicationUsage::USAGE_ANNOTATE))->getUrl();
 			if (xoctConf::getConfig(xoctConf::F_SIGN_ANNOTATION_LINKS)) {
-				$this->annotation_url = xoctSecureLink::sign($url);
+				$this->annotation_url = xoctSecureLink::signAnnotation($url);
 			} else {
-
 				$this->annotation_url = $url;
 			}
 		}
@@ -669,7 +668,7 @@ class xoctEvent extends APIObject {
 		if (!isset($this->download_url)) {
 			$url = $this->getFirstPublicationMetadataForUsage(xoctPublicationUsage::find(xoctPublicationUsage::USAGE_DOWNLOAD))->getUrl();
 			if (xoctConf::getConfig(xoctConf::F_SIGN_DOWNLOAD_LINKS)) {
-				$this->download_url = xoctSecureLink::sign($url);
+				$this->download_url = xoctSecureLink::signDownload($url);
 			} else {
 				$this->download_url = $url;
 			}

--- a/classes/Event/class.xoctEvent.php
+++ b/classes/Event/class.xoctEvent.php
@@ -652,7 +652,7 @@ class xoctEvent extends APIObject {
 		if (!isset($this->player_url)) {
 			$url = $this->getFirstPublicationMetadataForUsage(xoctPublicationUsage::find(xoctPublicationUsage::USAGE_PLAYER))->getUrl();
 			if (xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS)) {
-				$this->player_url = xoctSecureLink::sign($url);
+				$this->player_url = xoctSecureLink::signPlayer($url);
 			} else {
 				$this->player_url = $url;
 			}

--- a/classes/Player/class.xoctPlayerGUI.php
+++ b/classes/Player/class.xoctPlayerGUI.php
@@ -145,7 +145,7 @@ class xoctPlayerGUI extends xoctGUI
 
             $preview_url = $previews[$media->getRole()];
             if ($preview_url !== null) {
-                $preview_url = xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS) ? xoctSecureLink::sign($preview_url->getUrl()) : $preview_url->getUrl();
+                $preview_url = xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS) ? xoctSecureLink::signThumbnail($preview_url->getUrl()) : $preview_url->getUrl();
             } else {
                 $preview_url = "";
             }
@@ -258,8 +258,8 @@ class xoctPlayerGUI extends xoctGUI
                     $high_url = $high->getUrl();
                     $low_url = $low->getUrl();
                     if (xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS)) {
-                        $high_url = xoctSecureLink::sign($high_url);
-                        $low_url = xoctSecureLink::sign($low_url);
+                        $high_url = xoctSecureLink::signThumbnail($high_url);
+                        $low_url = xoctSecureLink::signThumbnail($low_url);
                     }
 
                     return [
@@ -282,7 +282,7 @@ class xoctPlayerGUI extends xoctGUI
 
                     $url = $preview->getUrl();
                     if (xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS)) {
-                        $url = xoctSecureLink::sign($url);
+                        $url = xoctSecureLink::signThumbnail($url);
                     }
 
                     return [

--- a/classes/Request/class.xoctRequest.php
+++ b/classes/Request/class.xoctRequest.php
@@ -461,16 +461,22 @@ class xoctRequest {
 	 *
 	 * @param null $valid_until
 	 *
+	 * @param null $ip
+	 *
 	 * @return string
 	 * @throws xoctException
 	 */
-	public function sign($url, $valid_until = null) {
+	public function sign($url, $valid_until = null, $ip = null) {
 		$this->checkBranch(array( self::BRANCH_SECURITY ));
 		$this->addPart('sign');
 		$data = array( 'url' => $url );
 
 		if ($valid_until) {
 			$data['valid-until'] = $valid_until;
+		}
+
+		if ($ip) {
+			$data['valid-source'] = $ip;
 		}
 
 		return $this->post($data);

--- a/classes/class.xoctSecureLink.php
+++ b/classes/class.xoctSecureLink.php
@@ -40,6 +40,25 @@ class xoctSecureLink {
 		return $data->url;
 	}
 
+
+	/**
+	 * @param   $url
+	 *
+	 * @param 0 $duration
+	 *
+	 * @return mixed
+	 * @throws xoctException
+	 */
+	public static function signPlayer($url, $duration = 0) {
+		$valid_until = null;
+		if (xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT) && $duration > 0) {
+			$duration_in_seconds = $duration / 1000;
+			$additional_time_percent = xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT) / 100;
+			$valid_until = gmdate("Y-m-d\TH:i:s\Z", time() + $duration_in_seconds + $duration_in_seconds * $additional_time_percent);
+		}
+		return self::sign($url, $valid_until, xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_WITH_IP));
+	}
+
 }
 
 ?>

--- a/classes/class.xoctSecureLink.php
+++ b/classes/class.xoctSecureLink.php
@@ -15,14 +15,16 @@ class xoctSecureLink {
 
 
 	/**
-	 * @param      $url
+	 * @param       $url
 	 *
-	 * @param null $valid_until
+	 * @param null  $valid_until
+	 *
+	 * @param false $restict_ip
 	 *
 	 * @return mixed
 	 * @throws xoctException
 	 */
-	public static function sign($url, $valid_until = null) {
+	public static function sign($url, $valid_until = null, $restict_ip = false) {
 		if (!$url) {
 			return '';
 		}
@@ -30,7 +32,9 @@ class xoctSecureLink {
 			return self::$cache[$url];
 		}
 
-		$data = json_decode(xoctRequest::root()->security()->sign($url, $valid_until));
+		$ip = ($restict_ip) ? $_SERVER['REMOTE_ADDR'] : null;
+
+		$data = json_decode(xoctRequest::root()->security()->sign($url, $valid_until, $ip));
 
 		if ($data->error) {
 			return '';

--- a/classes/class.xoctSecureLink.php
+++ b/classes/class.xoctSecureLink.php
@@ -42,6 +42,32 @@ class xoctSecureLink {
 
 
 	/**
+	 * @param $url
+	 *
+	 * @return mixed
+	 * @throws xoctException
+	 */
+	public static function signThumbnail($url) {
+		$duration = xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME);
+		$valid_until = ($duration > 0) ? gmdate("Y-m-d\TH:i:s\Z", time() + $duration) : null;
+		return self::sign($url, $valid_until, xoctConf::getConfig(xoctConf::F_SIGN_THUMBNAIL_LINKS_WITH_IP));
+	}
+
+
+	/**
+	 * @param $url
+	 *
+	 * @return mixed
+	 * @throws xoctException
+	 */
+	public static function signAnnotation($url) {
+		$duration = xoctConf::getConfig(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME);
+		$valid_until = ($duration > 0) ? gmdate("Y-m-d\TH:i:s\Z", time() + $duration) : null;
+		return self::sign($url, $valid_until, xoctConf::getConfig(xoctConf::F_SIGN_ANNOTATION_LINKS_WITH_IP));
+	}
+
+
+	/**
 	 * @param   $url
 	 *
 	 * @param 0 $duration
@@ -57,6 +83,19 @@ class xoctSecureLink {
 			$valid_until = gmdate("Y-m-d\TH:i:s\Z", time() + $duration_in_seconds + $duration_in_seconds * $additional_time_percent);
 		}
 		return self::sign($url, $valid_until, xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_WITH_IP));
+	}
+
+
+	/**
+	 * @param $url
+	 *
+	 * @return mixed
+	 * @throws xoctException
+	 */
+	public static function signDownload($url) {
+		$duration = xoctConf::getConfig(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME);
+		$valid_until = ($duration > 0) ? gmdate("Y-m-d\TH:i:s\Z", time() + $duration) : null;
+		return self::sign($url, $valid_until, xoctConf::getConfig(xoctConf::F_SIGN_DOWNLOAD_LINKS_WITH_IP));
 	}
 
 }

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -51,16 +51,20 @@ config_security_info#:#Erhöht die Sicherheit mithilfe von Opencasts "Stream Sec
 config_sign_annotation_links#:#Annotationslink signieren
 config_sign_annotation_links_time#:#Gültigkeit in Sekunden
 config_sign_annotation_links_time_info#:#Wie lange der Link für Annotation gültig sein soll. (0 entspricht Verwaltung durch Opencast)
+config_sign_annotation_links_with_ip#:#Für Client-IP signieren
 config_sign_player_links#:#Playerlink signieren
 config_sign_player_links_overwrite_default#:#Benutze Aufzeichnungsdauer als Dauer für die Gültigkeit der Signatur
 config_sign_player_links_additional_time_percent#:#Zusätzliche Zeit
 config_sign_player_links_additional_time_percent_info#:#Wieviel zusätzliche Zeit soll der Gültigkeit der Signatur in Prozent, abhängig von der Dauer, hinzugefügt werden?
+config_sign_player_links_with_ip#:#Für Client-IP signieren
 config_sign_download_links#:#Downloadlink signieren
 config_sign_download_links_time#:#Gültigkeit in Sekunden
 config_sign_download_links_time_info#:#Wie lange der Link für Download gültig sein soll. (0 entspricht Verwaltung durch Opencast)
+config_sign_download_links_with_ip#:#Für Client-IP signieren
 config_sign_thumbnail_links#:#Thumbnaillink signieren
 config_sign_thumbnail_links_time#:#Gültigkeit in Sekunden
 config_sign_thumbnail_links_time_info#:#Wie lange der Link für Thumbnail gültig sein soll. (0 entspricht Verwaltung durch Opencast)
+config_sign_thumbnail_links_with_ip#:#Für Client-IP signieren
 config_request_comb_lv#:#Request Kombinations Level
 config_request_comb_lv_info#:#Definiert die Zusammensetzung der Anfragen, mit welchen die Events von Opencast geholt werden (viele kleine/wenige grosse Anfragen). Dies hat keinen Einfluss auf die Funktionalität, beeinflusst jedoch die Performanz.
 config_groups#:#Opencast-Gruppen

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -49,12 +49,18 @@ config_advanced#:#Erweitert
 config_security#:#Security
 config_security_info#:#Erhöht die Sicherheit mithilfe von Opencasts "Stream Security". Nur aktivieren, wenn Opencast dafür konfiguriert ist.
 config_sign_annotation_links#:#Annotationslink signieren
+config_sign_annotation_links_time#:#Gültigkeit in Sekunden
+config_sign_annotation_links_time_info#:#Wie lange der Link für Annotation gültig sein soll. (0 entspricht Verwaltung durch Opencast)
 config_sign_player_links#:#Playerlink signieren
 config_sign_player_links_overwrite_default#:#Benutze Aufzeichnungsdauer als Dauer für die Gültigkeit der Signatur
 config_sign_player_links_additional_time_percent#:#Zusätzliche Zeit
 config_sign_player_links_additional_time_percent_info#:#Wieviel zusätzliche Zeit soll der Gültigkeit der Signatur in Prozent, abhängig von der Dauer, hinzugefügt werden?
 config_sign_download_links#:#Downloadlink signieren
+config_sign_download_links_time#:#Gültigkeit in Sekunden
+config_sign_download_links_time_info#:#Wie lange der Link für Download gültig sein soll. (0 entspricht Verwaltung durch Opencast)
 config_sign_thumbnail_links#:#Thumbnaillink signieren
+config_sign_thumbnail_links_time#:#Gültigkeit in Sekunden
+config_sign_thumbnail_links_time_info#:#Wie lange der Link für Thumbnail gültig sein soll. (0 entspricht Verwaltung durch Opencast)
 config_request_comb_lv#:#Request Kombinations Level
 config_request_comb_lv_info#:#Definiert die Zusammensetzung der Anfragen, mit welchen die Events von Opencast geholt werden (viele kleine/wenige grosse Anfragen). Dies hat keinen Einfluss auf die Funktionalität, beeinflusst jedoch die Performanz.
 config_groups#:#Opencast-Gruppen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -51,16 +51,20 @@ config_security_info#:#Improves the security by using Opencasts "Stream Security
 config_sign_annotation_links#:#Sign Annotation Link
 config_sign_annotation_links_time#:#Validity in seconds
 config_sign_annotation_links_time_info#:#How long the Annotation-Link should be valid for. (0 uses setting from OpenCast)
+config_sign_annotation_links_with_ip#:#Sign for client IP
 config_sign_player_links#:#Sign Player Link
 config_sign_player_links_overwrite_default#:#Use event duration for the validity of the signature
 config_sign_player_links_additional_time_percent#:#Additional Time
 config_sign_player_links_additional_time_percent_info#:#How much additional time should be added to the validity of the signature in percent, depending on the event duration?
+config_sign_player_links_with_ip#:#Sign for client IP
 config_sign_download_links#:#Sign Download Link
 config_sign_download_links_time#:#Validity in seconds
 config_sign_download_links_time_info#:#How long the Download-Link should be valid for. (0 uses setting from OpenCast)
+config_sign_download_links_with_ip#:#Sign for client IP
 config_sign_thumbnail_links#:#Sign Thumbnail Link
 config_sign_thumbnail_links_time#:#Validity in seconds
 config_sign_thumbnail_links_time_info#:#How long the Thumbnail-Link should be valid for. (0 uses setting from OpenCast)
+config_sign_thumbnail_links_with_ip#:#Sign for client IP
 config_request_comb_lv#:#Request Combination Level
 config_request_comb_lv_info#:#Defines the way the plugin is sending requests to fetch events from Opencast (many small/few large requests). This has no impact on the functionality, yet it affects the performance.
 config_groups#:#Opencast Groups

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -49,12 +49,18 @@ config_advanced#:#Advanced
 config_security#:#Security
 config_security_info#:#Improves the security by using Opencasts "Stream Security". Only activate, if Opencast is configured to use it.
 config_sign_annotation_links#:#Sign Annotation Link
+config_sign_annotation_links_time#:#Validity in seconds
+config_sign_annotation_links_time_info#:#How long the Annotation-Link should be valid for. (0 uses setting from OpenCast)
 config_sign_player_links#:#Sign Player Link
 config_sign_player_links_overwrite_default#:#Use event duration for the validity of the signature
 config_sign_player_links_additional_time_percent#:#Additional Time
 config_sign_player_links_additional_time_percent_info#:#How much additional time should be added to the validity of the signature in percent, depending on the event duration?
 config_sign_download_links#:#Sign Download Link
+config_sign_download_links_time#:#Validity in seconds
+config_sign_download_links_time_info#:#How long the Download-Link should be valid for. (0 uses setting from OpenCast)
 config_sign_thumbnail_links#:#Sign Thumbnail Link
+config_sign_thumbnail_links_time#:#Validity in seconds
+config_sign_thumbnail_links_time_info#:#How long the Thumbnail-Link should be valid for. (0 uses setting from OpenCast)
 config_request_comb_lv#:#Request Combination Level
 config_request_comb_lv_info#:#Defines the way the plugin is sending requests to fetch events from Opencast (many small/few large requests). This has no impact on the functionality, yet it affects the performance.
 config_groups#:#Opencast Groups

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -176,3 +176,9 @@ xoctOpenCast::updateDB();
 global $DIC;
 $DIC->database()->query('ALTER TABLE sr_chat_message MODIFY message varchar(512)');
 ?>
+<#20>
+<?php
+xoctConf::set(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME, 0);
+xoctConf::set(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME, 0);
+xoctConf::set(xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME, 0);
+?>

--- a/sql/dbupdate.php
+++ b/sql/dbupdate.php
@@ -179,6 +179,10 @@ $DIC->database()->query('ALTER TABLE sr_chat_message MODIFY message varchar(512)
 <#20>
 <?php
 xoctConf::set(xoctConf::F_SIGN_ANNOTATION_LINKS_TIME, 0);
+xoctConf::set(xoctConf::F_SIGN_ANNOTATION_LINKS_WITH_IP, 0);
 xoctConf::set(xoctConf::F_SIGN_DOWNLOAD_LINKS_TIME, 0);
+xoctConf::set(xoctConf::F_SIGN_DOWNLOAD_LINKS_WITH_IP, 0);
 xoctConf::set(xoctConf::F_SIGN_THUMBNAIL_LINKS_TIME, 0);
+xoctConf::set(xoctConf::F_SIGN_THUMBNAIL_LINKS_WITH_IP, 0);
+xoctConf::set(xoctConf::F_SIGN_PLAYER_LINKS_WITH_IP, 0);
 ?>


### PR DESCRIPTION
Hello there,

we noticed that setting the signing duration (valid-until) based on video-length was only implemented for the HLS/Dash URLs, eg.  when using a streaming server, but not when using the publications directly. 

We refactored the code a bit and also implemented this feature when not using a streaming server, see d12a6512bab54f2d46ff5097434f1e16e4aa4b77 .

While we where at it, we also implemented using different duration (valid-until) settings for Annotation-, Thumbnail- and Download-Links, see 5f8a04be1c2eb2fe1b1af7fcae405a4d10bcc98e .
This way you can use different values for all links, eg. short duration for thumbnail, longer for download and annotation, etc.

Additionally we also implemented signing links for the current client/user IP only, see c4e8709d9b186c666d165da5b94310f9fd58e640 .
This way its possible to even better restrict the links generated by the ILIAS plugin when desired.

Additional Options screenshot:
![Screenshot_20200513_100743](https://user-images.githubusercontent.com/11391961/81802394-4228a300-9516-11ea-8e94-b321ad9b20c2.png)

BR,
Thomas (Uni Marburg)

