### PR TITLE
Add support for Opencast Studio return link

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -509,16 +509,24 @@ class xoctEventGUI extends xoctGUI {
 
 
 	/**
-	 * 
+	 *
 	 */
 	public function opencaststudio(){
 		$xoctSeries =  $this->xoctOpenCast->getSeriesIdentifier();
 		$base = rtrim(xoctConf::getConfig(xoctConf::F_API_BASE), "/");
 		$base = str_replace('/api', '', $base);
-		$studio_link = $base . '/studio' . '?upload.seriesId=' . $xoctSeries;
+
+		$schema = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http";
+		$return_link =  $schema . '://' . $_SERVER['HTTP_HOST'] . '/'
+			. self::dic()->ctrl()->getLinkTarget($this, self::CMD_STANDARD);
+
+		$studio_link = $base . '/studio'
+			. '?upload.seriesId=' . $xoctSeries
+			. '&return.label=ILIAS'
+			. '&return.target=' . urlencode($return_link);
 		header('Location:' . $studio_link);
 	}
-		
+
 
 	/**
 	 *


### PR DESCRIPTION
Opencast Studio added support for passing a return link (including
a label). Studio then shows a "Quit and go back" button in the last
step (after recording). This avoids users getting trapped in UI
dead ends.

See this Studio PR for more information:
   https://github.com/elan-ev/opencast-studio/pull/674

Note that on older Studio versions, adding these parameters does
nothing. A warning about "unknown parameter" is printed in the
browser dev console, but other than that, the parameters are
ignored.

One might think about making the label configurable in the plugin's
configuration. But "ILIAS" is a good default I guess.

---

I have *very* little experience with PHP and this is the first time I worked with the ILIAS codebase. If there is anything I can improve about the code, please let me know!

And: if you won't be able to merge this PR anytime soon (vacation or whatever reasons), please let me know. Thanks :)