### PR TITLE
Download event button has now the option "External download Source"

### DIFF
--- a/classes/Conf/class.xoctConf.php
+++ b/classes/Conf/class.xoctConf.php
@@ -57,6 +57,7 @@ class xoctConf extends ActiveRecord {
 	const F_AUDIO_ALLOWED = 'audio_allowed';
 	const F_CREATE_SCHEDULED_ALLOWED = 'create_scheduled_allowed';
 	const F_STUDIO_ALLOWED = 'oc_studio_allowed';
+	const F_EXT_DL_SOURCE = 'external_download_source';
 	const F_VIDEO_PORTAL_LINK = 'video_portal_link';
 	const F_VIDEO_PORTAL_TITLE = 'video_portal_title';
 	const F_ENABLE_LIVE_STREAMS = 'enable_live_streams';

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -215,6 +215,10 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$cb->setInfo($this->parent_gui->txt(xoctConf::F_CREATE_SCHEDULED_ALLOWED . '_info'));
 		$this->addItem($cb);
 
+		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_EXT_DL_SOURCE), xoctConf::F_EXT_DL_SOURCE);
+		$cb->setInfo($this->parent_gui->txt(xoctConf::F_EXT_DL_SOURCE . '_info'));
+		$this->addItem($cb);
+
 		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_STUDIO_ALLOWED), xoctConf::F_STUDIO_ALLOWED);
 		$cb->setInfo($this->parent_gui->txt(xoctConf::F_STUDIO_ALLOWED . '_info'));
 		$this->addItem($cb);

--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -587,13 +587,19 @@ class xoctEventGUI extends xoctGUI {
         curl_exec($ch);
         $size = curl_getinfo($ch, CURLINFO_CONTENT_LENGTH_DOWNLOAD);
         curl_close($ch);
-
+		if(xoctConf::getConfig(xoctConf::F_EXT_DL_SOURCE)){
+			// Open external source page
+			header('Location: '.$url);
+		} else {
         // deliver file
-        header('Content-Description: File Transfer');
-        header('Content-Type: ' . $publication->getMediatype());
-        header('Content-Disposition: attachment; filename="' . $event->getTitle() . '.' . $extension . '"');
-        header('Content-Length: ' . $size);
-        readfile($url);
+        	header('Content-Description: File Transfer');
+        	header('Content-Type: ' . $publication->getMediatype());
+        	header('Content-Disposition: attachment; filename="' . $event->getTitle() . '.' . $extension . '"');
+        	header('Content-Length: ' . $size);
+			readfile($url);
+		}
+		
+		
         exit;
     }
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -21,6 +21,8 @@ config_editor_link#:#Link zum Opencast-Video-Editor
 config_editor_link_info#:#Link, welcher für die Aktion "Schneiden" verwendet wird. Als Platzhalter kann &#123event_id} verwendet werden. Default: https://[ihre-opencast-url.de]/admin-ng/index.html#!/events/events/&#123event_id}/tools/editor
 config_eula#:#Nutzungsvereinbarung
 config_events#:#Aufzeichnungen
+config_external_download_source#:#Externe Downloadquelle
+config_external_download_source_info#:#Aktivieren Sie diese Option im Falle einer externen Webseite, um die Downloads anzuzeigen
 config_series#:#Serien
 config_licenses#:#Lizenzen
 config_licenses_info#:#Neue Einträge auf neuer Zeile in der Form URL#Name hinzufügen

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -11,6 +11,8 @@ config_audio_allowed#:#Audio Files
 config_cancel#:#Cancel
 config_create_scheduled_allowed#:#Activate "Schedule Event(s)"
 config_create_scheduled_allowed_info#:#Warning: Scheduling events requires Opencast API v1.1.0.
+config_external_download_source#:#External download source
+config_external_download_source_info#:#Enable this option in case of an external web page to show the downloads
 config_oc_studio_allowed#:#Enable Opencast Studio
 config_oc_studio_allowed_info#:#Allow users to access to Opencast Studio from Ilias (Requires Opencast > 8.3)
 config_curl#:#cURL


### PR DESCRIPTION
This option changes the button behavior, from download the media file from the event to open the download source on the web browser. Useful when is in use with an external site.

This option is available in the Events tab from the plugin configuration.