### PR TITLE
upload .m4v files

### DIFF
--- a/src/UI/Input/EventFormGUI.php
+++ b/src/UI/Input/EventFormGUI.php
@@ -235,6 +235,7 @@ class EventFormGUI extends ilPropertyFormGUI {
 				'video/x-matroska',
 				'video/x-msvideo',
 				'video/x-dv',
+                'video/x-m4v',
 				'audio/mp4',
 				'audio/x-m4a',
 				'audio/ogg',
@@ -260,6 +261,7 @@ class EventFormGUI extends ilPropertyFormGUI {
 				'video/x-matroska',
 				'video/x-msvideo',
 				'video/x-dv',
+                'video/x-m4v'
 			));
 			$te->setRequired(true);
 			$this->addItem($te);


### PR DESCRIPTION
In Firefox I could not upload .m4v files.
Fixed by adding it to the list of MIME-types