### PR TITLE
Fix Opencast Studio return link for Ilias 5.x

### DIFF
--- a/classes/Event/class.xoctEventGUI.php
+++ b/classes/Event/class.xoctEventGUI.php
@@ -517,7 +517,7 @@ class xoctEventGUI extends xoctGUI {
 		$base = str_replace('/api', '', $base);
 
 		$return_link =  ILIAS_HTTP_PATH . '/'
-			. self::dic()->ctrl()->getLinkTarget($this, self::CMD_STANDARD);
+			. self::dic()->ctrl()->getLinkTarget($this, self::CMD_STANDARD, '', false, false);
 
 		$studio_link = $base . '/studio'
 			. '?upload.seriesId=' . $xoctSeries


### PR DESCRIPTION
The `getLinkTarget` method in Ilias 5.4 has `xmlStyle` default to `true`
(see [1]). In Ilias 6.0, it defaults to `false` instead (see [2]). We
need this to be `false` as otherwise `&` gets turned into `&amp;` which
Opencast Studio does not decode. To ensure this works with both Ilias
versions, we just specify the parameters explicitly.

[1]: http://ildoc.hrz.uni-giessen.de/ildoc/release_5-4/html/d9/d05/classilCtrl.html#af1e03eb3719c5d2891a8e9381940425d
[2]: http://ildoc.hrz.uni-giessen.de/ildoc/release_6/html/d9/d05/classilCtrl.html#add1a0ceadd022159137cb5ccfb9bd364