### PR TITLE
Adds "Presenter name mandatory" as a new setting

### DIFF
--- a/classes/Conf/class.xoctConf.php
+++ b/classes/Conf/class.xoctConf.php
@@ -78,6 +78,7 @@ class xoctConf extends ActiveRecord {
 	const NO_METADATA = 0;
 	const ALL_METADATA = 1;
 	const METADATA_EXCEPT_DATE_PLACE = 2;
+	const F_PRESENTER_MANDATORY = 'presenter_mandatory';
 
 	const F_USE_STREAMING = 'use_streaming';
     const F_STREAMING_URL = 'streaming_url';

--- a/classes/Conf/class.xoctConfFormGUI.php
+++ b/classes/Conf/class.xoctConfFormGUI.php
@@ -326,6 +326,11 @@ class xoctConfFormGUI extends ilPropertyFormGUI {
 		$ro = new ilRadioOption($this->parent_gui->txt(xoctConf::F_SCHEDULED_METADATA_EDITABLE . '_' . xoctConf::METADATA_EXCEPT_DATE_PLACE), xoctConf::METADATA_EXCEPT_DATE_PLACE);
 		$ri->addOption($ro);
 		$this->addItem($ri);
+
+		// MAKE PRESENTER FIELD MANDATORY
+		$cb = new ilCheckboxInputGUI($this->parent_gui->txt(xoctConf::F_PRESENTER_MANDATORY), xoctConf::F_PRESENTER_MANDATORY);
+		$cb->setInfo($this->parent_gui->txt(xoctConf::F_PRESENTER_MANDATORY . '_info'));
+		$this->addItem($cb);
 	}
 
 

--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -130,6 +130,8 @@ config_video_portal_title#:#Bezeichung des externen Videoportals
 config_video_portal_link#:#Link zu externem Videoportal
 config_video_portal_link_info#:#Wird in den Einstellungen und im Infotab einer Serie angezeigt. Als Platzhalter kann &#123series_id} verwendet werden. Bsp: https://myopencast-tube.com/cast/channels/&#123series_id}
 config_permission_templates#:#Berechtigungsvorlagen
+config_presenter_mandatory#:#Name des Präsentators ist Pflichtfeld
+config_presenter_mandatory_info#:# Macht das Schreiben des Präsentatornamens für einen Event-Upload Pflicht.
 config_upload_chunk_size#:#Upload-Chunk-Größe (MB)
 config_upload_chunk_size_info#:#Der Video-Upload erfolgt stückweise, wobei ein Stück die hier angegebene Größe hat. Das Erhöhen dieser Größe kann die Upload-Geschwindigkeit verbessern, wobei allerdings auf das Upload-Limit geachtet werden sollte. Standard: 20MB
 config_btn_load_parameters#:#Parameter via API Laden

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -131,6 +131,8 @@ config_video_portal_title#:#Title of external Video Portal
 config_video_portal_link#:#Link to external Video Portal
 config_video_portal_link_info#:#Will be displayed in the settings and info tab of a series. &#123series_id} can be used as a placeholder. E.g.: https://myopencast-tube.com/cast/channels/&#123series_id}
 config_permission_templates#:#Permission Templates
+config_presenter_mandatory#:#Presenter name mandatory
+config_presenter_mandatory_info#:# Makes mandatory write the presenter name for an event upload
 config_upload_chunk_size#:#Upload chunk size (MB)
 config_upload_chunk_size_info#:#The video upload is separated in chunks, whereas one chunk has the here defined size. Increasing the chunk size can improve the upload speed. Default: 20MB
 config_btn_load_parameters#:#Load Parameters via API

--- a/src/UI/Input/EventFormGUI.php
+++ b/src/UI/Input/EventFormGUI.php
@@ -276,9 +276,10 @@ class EventFormGUI extends ilPropertyFormGUI {
 		$this->addItem($te);
 
 		$te = new ilTextInputGUI($this->txt(self::F_PRESENTERS), self::F_PRESENTERS);
-		$te->setRequired($this->schedule);
+		if (xoctConf::getConfig(xoctConf::F_PRESENTER_MANDATORY) || $this->schedule){
+			$te->setRequired(true);
+		}
 		$this->addItem($te);
-
 
 		// show location and start date for scheduled events only if configured
         $date_and_location_disabled = $this->object->isScheduled() && xoctConf::getConfig(xoctConf::F_SCHEDULED_METADATA_EDITABLE) == xoctConf::METADATA_EXCEPT_DATE_PLACE;


### PR DESCRIPTION
This is a new feature, makes the `Presenter name` to be obligatory to insert when you upload a new event.

This feature can be turned off in the settings.