### PR TITLE
Fix Annotation Tool signature issues

### DIFF
--- a/src/Model/Config/PublicationUsage/PublicationSelector.php
+++ b/src/Model/Config/PublicationUsage/PublicationSelector.php
@@ -347,17 +347,11 @@ class PublicationSelector
                 $media_url = $media_object->getUrl();
 
                 if (xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS)) {
-                    //get duration and calculate expire date
+                    // Get duration from metadata
                     $duration = $media_object->duration;
 
-                    $valid_until = null;
-                    if (xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_OVERWRITE_DEFAULT)) {
-                        $duration_in_seconds = $duration / 1000;
-                        $additional_time_percent = xoctConf::getConfig(xoctConf::F_SIGN_PLAYER_LINKS_ADDITIONAL_TIME_PERCENT) / 100;
-                        $valid_until = gmdate("Y-m-d\TH:i:s\Z", time() + $duration_in_seconds + $duration_in_seconds * $additional_time_percent);
-                    }
-                    // Sign the url and parse the variables.
-                    $media_url_signed = xoctSecureLink::signPlayer($media_url, $valid_until);
+                    // Sign the url and parse variables
+                    $media_url_signed = xoctSecureLink::signPlayer($media_url, $duration);
                     $media_url_query = parse_url($media_url_signed, PHP_URL_QUERY);
                     $media_url = $media_url . '&' . $media_url_query;
                 }


### PR DESCRIPTION
Fixes Annotation Tools signatures issues. 

The sign method now makes all the logic, now only it's necessary to pass the duration in milliseconds.