### PR TITLE
use streaming urls from configured publications

### DIFF
--- a/classes/Event/Publication/class.xoctMedia.php
+++ b/classes/Event/Publication/class.xoctMedia.php
@@ -31,6 +31,14 @@ class xoctMedia extends xoctPublicationMetadata {
 	 * @var int
 	 */
 	public $height;
+	/**
+	 * @var int
+	 */
+	public $id;
+	/**
+	 * @var bool
+	 */
+	public $is_master_playlist;
 
 
 	/**
@@ -126,5 +134,22 @@ class xoctMedia extends xoctPublicationMetadata {
 	 */
 	public function setHeight($height) {
 		$this->height = $height;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getId() {
+		return $this->id;
+	}
+
+	/**
+	 * @return bool
+	 */
+	public function is_master_playlist() {
+            if (isset($this->is_master_playlist)) 
+	        return $this->is_master_playlist;
+	    else 
+	        return true;
 	}
 }


### PR DESCRIPTION
Hi,
this PR enables the previously missing functionality to use streaming URLs from publications instead of building them mostly static. The code uses the configured player publication channel and adds the URLs for mp4 and HLS to the array that is later used by the paella player if they are available. The order of video factories in paella is now important in the case that both mp4 and HLS URLs were sent to the paella player.

Streaming URLs can be part of a publication channel if either the default engage-player publication of opencast or a publish-configure operation `<configuration key="with-published-elements">true</configuration>` with published elements set to true is used to publish events. 

This PR also adds support for the soon-to-be added new feature in opencast to mark playlist files as `is_master_playlist = true` https://github.com/opencast/opencast/pull/2814
This PR should be compatible with the old static streaming URLs configuration which remains untouched to ensure backwards compatibility.

Suggestions for improvements are of course welcome.

Code written by Ruth. Tested with Educast.nrw and University of Cologne Opencast systems.

