### PR TITLE
add note to owner prefix

### DIFF
--- a/lang/ilias_de.lang
+++ b/lang/ilias_de.lang
@@ -92,7 +92,7 @@ config_workflow_unpublish_info#:#ID des workflows, welcher vor dem Löschen eine
 config_user_mapping_info#:#Benutzerfeld in ILIAS, welches zur Identifikation eines Benutzers in Opencast verwendet werden soll. <br><b>Achtung: Die Email-Adresse kann je nach ILIAS-Konfiguration durch den Benutzer selbst geändert werden. In diesem Fall sollte Email-Adresse auf keinen Fall als Mapping verwendet werden.</b>
 config_group_producers_info#:#Benutzer mit dem Recht "Videos editieren" werden vom Plugin in der hier angegebenen Opencast-Gruppe eingeschrieben, um dadurch Zugriff auf Opencast zu erhalten.
 config_role_user_prefix_info#:#Benutzereigene Rolle in Opencast. Wird auf Serien gesetzt, um dem Benutzer genügend Rechte in Opencast einzuräumen. Bsp: ROLE_USER_&#123IDENTIFIER}
-config_role_owner_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in Opencast existieren. Bsp: ROLE_OWNER_&#123IDENTIFIER}
+config_role_owner_prefix_info#:#Gibt den Besitzer eines Events an. Diese Rolle muss NICHT in Opencast existieren. Bsp: ROLE_OWNER_&#123IDENTIFIER}. NICHT den gleichen Wert wie für Benutzerrolle wählen.
 config_identifier_to_uppercase#:#User-Mapping in Grossbuchstaben
 config_no_metadata#:#Ohne Metadaten
 config_no_metadata_info#:#Ab API Version 1.1.0 müssen die Metadaten nicht mehr separat geholt werden, mit dieser Option kann somit die Performanz verbessert werden. In allen älteren Versionen wird diese Option allerdings zu einem Fehler führen.

--- a/lang/ilias_en.lang
+++ b/lang/ilias_en.lang
@@ -94,7 +94,7 @@ config_workflow_unpublish_info#:#ID of the workflow which will be executed in Op
 config_user_mapping_info#:#Userfield in ILIAS which will be used to identify the user in Opencast.<br><b>Warning: depending on the ILIAS configuration, users may be able to change their own email address. It is strongly recommended not to use email as mapping in that case.</b>
 config_group_producers_info#:#Users with the permission "Edit Videos" will be assigned to this Opencast group to obtain access to Opencast.
 config_role_user_prefix_info#:#User specific role in Opencast. Is used to grant the user permission on a series in Opencast. Example: ROLE_USER_&#123IDENTIFIER}
-config_role_owner_prefix_info#:#Indicates the owner of an event. This rules doesn't have to exist in Opencast. Example: ROLE_OWNER_&#123IDENTIFIER}
+config_role_owner_prefix_info#:#Indicates the owner of an event. This rules doesn't have to exist in Opencast. Example: ROLE_OWNER_&#123IDENTIFIER}. DO NOT use the same value as for the user specific role.
 config_identifier_to_uppercase#:#User mapping in uppercase
 config_no_metadata#:#Without Metadata
 config_no_metadata_info#:#The metadata don't need to be fetched seperately in the latest API versions, therefore this option will improve the performance. However, this will lead to an error in previous versions.


### PR DESCRIPTION
Add advice to configuration hints regarding the ROLE_OWNER_{IDENTIFIER}. It is highly recommended using the suggested value and to not use the same value as the user specific role (ROLE_USER_{IDENTIFIER}). If the same role pattern is used the owner can not be determined by the plugin and one (not a specific) user is shown as owner.