### PR TITLE
added .mkv to list of supported file formats

### DIFF
--- a/src/UI/Input/EventFormGUI.php
+++ b/src/UI/Input/EventFormGUI.php
@@ -218,7 +218,8 @@ class EventFormGUI extends ilPropertyFormGUI {
 				'ogg',
 				'flac',
 				'aiff',
-				'wav'
+				'wav',
+				'mkv'
 			) : array(
 				'mov',
 				'mp4',
@@ -227,6 +228,7 @@ class EventFormGUI extends ilPropertyFormGUI {
 				'mpeg',
 				'avi',
 				'mp4',
+				'mkv'
 			));
 			$te->setMimeTypes($allow_audio ? array(
 				'video/avi',


### PR DESCRIPTION
This will add mkv to the list of supported file-formats.
The list shows up when manually uploading a video.
The format .mkv is already supported and no other change is necessary.